### PR TITLE
Revert "Support specify v2ray config file by using env variable"

### DIFF
--- a/Formula/v2ray-core.rb
+++ b/Formula/v2ray-core.rb
@@ -40,9 +40,9 @@ class V2rayCore < Formula
       <string>#{plist_name}</string>
       <key>ProgramArguments</key>
       <array>
-        <string>/bin/sh</string>
-        <string>-c</string>
-        <string>#{bin}/v2ray -config "${V2RAY_CONFIG:-#{etc}/v2ray/config.json}"</string>
+        <string>#{bin}/v2ray</string>
+        <string>-config</string>
+        <string>#{etc}/v2ray/config.json</string>
       </array>
     </dict>
   </plist>

--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ or run v2ray-core and register it to launch at login via:
 brew services start v2ray-core
 ```
 
-to specify your own configuration file, please use `V2RAY_CONFIG` environment variable:
 
-```bash
-launchctl setenv V2RAY_CONFIG <CONFIG_FILE>
-brew services restart v2ray-core # don't forget restart the service.
-```
+
+


### PR DESCRIPTION
Reverts v2ray/homebrew-v2ray#13

V2RAY_LOCATION_CONFIG is supported by default